### PR TITLE
V1.1.3p2

### DIFF
--- a/db/migration_v1.1.3p2.sql
+++ b/db/migration_v1.1.3p2.sql
@@ -1,0 +1,4 @@
+IF EXISTS (SELECT 1 FROM dsc_infra_info WHERE id = 1)
+	UPDATE dsc_infra_info SET db_version = '1.1.3p2', updated_at = GETDATE() WHERE id = 1;
+ELSE
+	INSERT INTO dsc_infra_info (id, web_version, db_version, updated_at) VALUES (1, '0.0.1', '1.1.3p2', GETDATE());

--- a/db/schema_mssql.sql
+++ b/db/schema_mssql.sql
@@ -76,7 +76,7 @@ IF NOT EXISTS (SELECT * FROM sysobjects WHERE name='dsc_infra_info' AND xtype='U
 CREATE TABLE dsc_infra_info (
     id INT PRIMARY KEY CHECK (id = 1),
     web_version NVARCHAR(20) DEFAULT '0.0.1',
-    db_version NVARCHAR(20) DEFAULT '1.1.3',
+    db_version NVARCHAR(20) DEFAULT '1.1.3p2',
     latest_release NVARCHAR(50) NULL,
     latest_release_url NVARCHAR(255) NULL,
     update_available BIT DEFAULT 0,
@@ -85,7 +85,7 @@ CREATE TABLE dsc_infra_info (
     updated_at DATETIME DEFAULT GETDATE()
 );
 IF NOT EXISTS (SELECT 1 FROM dsc_infra_info WHERE id = 1)
-    INSERT INTO dsc_infra_info (id, web_version, db_version, updated_at) VALUES (1, '0.0.1', '1.1.3', GETDATE());
+    INSERT INTO dsc_infra_info (id, web_version, db_version, updated_at) VALUES (1, '0.0.1', '1.1.3p2', GETDATE());
 
 IF EXISTS (SELECT * FROM sysobjects WHERE name='dsc_infra_info' AND xtype='U')
 BEGIN
@@ -128,7 +128,7 @@ IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'idx_scheduler_runs_task_s
     CREATE INDEX idx_scheduler_runs_task_started ON scheduler_task_runs(task_name, started_at DESC);
 
 -- To update version:
--- UPDATE dsc_infra_info SET db_version = '1.1.2p2', updated_at = GETDATE() WHERE id = 1;
+-- UPDATE dsc_infra_info SET db_version = '1.1.3p2', updated_at = GETDATE() WHERE id = 1;
 
 IF NOT EXISTS (SELECT * FROM sysobjects WHERE name='agents' AND xtype='U')
 CREATE TABLE agents (

--- a/db/schema_sqlite.sql
+++ b/db/schema_sqlite.sql
@@ -51,7 +51,7 @@ CREATE INDEX IF NOT EXISTS idx_reports_agent_id ON reports(agent_id);
 CREATE TABLE IF NOT EXISTS dsc_infra_info (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     web_version TEXT DEFAULT '0.0.1',
-    db_version TEXT DEFAULT '1.1.3',
+    db_version TEXT DEFAULT '1.1.3p2',
     latest_release TEXT,
     latest_release_url TEXT,
     update_available INTEGER DEFAULT 0,
@@ -59,8 +59,8 @@ CREATE TABLE IF NOT EXISTS dsc_infra_info (
     release_checked_at TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-INSERT OR IGNORE INTO dsc_infra_info (id, web_version, db_version, updated_at) VALUES (1, '0.0.1', '1.1.3', CURRENT_TIMESTAMP);
-UPDATE dsc_infra_info SET db_version = '1.1.3', updated_at = CURRENT_TIMESTAMP WHERE id = 1;
+INSERT OR IGNORE INTO dsc_infra_info (id, web_version, db_version, updated_at) VALUES (1, '0.0.1', '1.1.3p2', CURRENT_TIMESTAMP);
+UPDATE dsc_infra_info SET db_version = '1.1.3p2', updated_at = CURRENT_TIMESTAMP WHERE id = 1;
 
 CREATE TABLE IF NOT EXISTS scheduler_tasks (
     task_name TEXT PRIMARY KEY,

--- a/handlers/sendreport.go
+++ b/handlers/sendreport.go
@@ -106,24 +106,43 @@ func SendReportHandler(w http.ResponseWriter, r *http.Request) {
 					log.Printf("[SENDREPORT] Erreur insertion rapport en base: %v", err)
 				}
 			}
-			   // Met à jour last_communication et has_error_last_report uniquement pour les rapports Initial
-			   hasError := 0
-			   if report.OperationType == "Initial" {
-					log.Printf("[SENDREPORT] Initial report received, updating last_communication and has_error_last_report")
-				   if strings.ToLower(report.Status) == "failure" {
-					   hasError = 1
-				   }
-				   _, err = database.Exec("UPDATE agents SET last_communication = CURRENT_TIMESTAMP, has_error_last_report = ?, state = ? WHERE agent_id = ?", hasError, report.Status, agentId)
-				   if err != nil {
-					   log.Printf("[SENDREPORT] Erreur update last_communication/has_error_last_report: %v", err)
-				   }
-			   } else {
-				   // Pour les autres types de rapport, on met juste à jour last_communication
-				   _, err = database.Exec("UPDATE agents SET last_communication = CURRENT_TIMESTAMP WHERE agent_id = ?", agentId)
-				   if err != nil {
-					   log.Printf("[SENDREPORT] Erreur update last_communication: %v", err)
-				   }
-			   }
+			// Toujours mettre a jour le heartbeat agent.
+			_, err = database.Exec("UPDATE agents SET last_communication = CURRENT_TIMESTAMP WHERE agent_id = ?", agentId)
+			if err != nil {
+				log.Printf("[SENDREPORT] Erreur update last_communication: %v", err)
+			}
+
+			hasReportErrors := false
+			for _, reportErr := range report.Errors {
+				errText := strings.TrimSpace(reportErr)
+				if errText != "" && errText != "[]" && errText != "{}" && strings.ToLower(errText) != "null" {
+					hasReportErrors = true
+					break
+				}
+			}
+
+			// Regle metier:
+			// - MOF: success => OK, tout autre statut => KO
+			// - Sans MOF: erreurs explicites => KO, sinon ne pas modifier l etat
+			if mofApplied == 1 {
+				hasError := 1
+				state := "Failure"
+				if strings.ToLower(strings.TrimSpace(report.Status)) == "success" {
+					hasError = 0
+					state = "Success"
+				}
+				_, err = database.Exec("UPDATE agents SET has_error_last_report = ?, state = ? WHERE agent_id = ?", hasError, state, agentId)
+				if err != nil {
+					log.Printf("[SENDREPORT] Erreur update has_error_last_report/state: %v", err)
+				}
+			} else if hasReportErrors {
+				_, err = database.Exec("UPDATE agents SET has_error_last_report = ?, state = ? WHERE agent_id = ?", 1, "Failure", agentId)
+				if err != nil {
+					log.Printf("[SENDREPORT] Erreur update has_error_last_report/state (no MOF + errors): %v", err)
+				}
+			} else {
+				log.Printf("[SENDREPORT] Rapport ignore pour l etat web (mof_applied=0): agent_id=%s, job_id=%s, operation_type=%s", agentId, report.JobId, report.OperationType)
+			}
 			database.Close()
 		}
 	}

--- a/web/scheduler_config.js
+++ b/web/scheduler_config.js
@@ -133,6 +133,18 @@ $(function() {
             .replace(/>/g, '&gt;');
     }
 
+    function safeAttr(v) {
+        if (v === null || v === undefined || v === '') {
+            return '-';
+        }
+        return String(v)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     function formatDateWithTimezone(value) {
         if (!value) {
             return '-';
@@ -178,9 +190,9 @@ $(function() {
                         '<td>' + formatDateWithTimezone(task.last_run_at) + '</td>' +
                         '<td>' + statusBadge(task.last_status) + note + '</td>' +
                         '<td>' +
-                            '<button type="button" class="btn btn-sm btn-outline-primary js-task-history" data-task="' + safe(task.task_name) + '">History</button> ' +
-                            '<button type="button" class="btn btn-sm btn-outline-secondary js-task-configure" data-task="' + safe(task.task_name) + '">Configure</button> ' +
-                            '<button type="button" class="btn btn-sm btn-outline-success js-task-run" data-task="' + safe(task.task_name) + '" ' + runBtnDisabled + '>Run</button>' +
+                            '<button type="button" class="btn btn-sm btn-outline-primary js-task-history" data-task="' + safeAttr(task.task_name) + '">History</button> ' +
+                            '<button type="button" class="btn btn-sm btn-outline-secondary js-task-configure" data-task="' + safeAttr(task.task_name) + '">Configure</button> ' +
+                            '<button type="button" class="btn btn-sm btn-outline-success js-task-run" data-task="' + safeAttr(task.task_name) + '" ' + runBtnDisabled + '>Run</button>' +
                         '</td>' +
                     '</tr>';
                 }).join('');


### PR DESCRIPTION
# Release v1.1.3p2

Date: 2026-06-13

Patch release focused on security hardening in the scheduler UI and status handling after agent reports.

## Changes

### Security

- Fixed incomplete HTML attribute sanitization in scheduler task action buttons.
- Added attribute-context escaping for values injected in data-task attributes.

### Agent status behavior after SendReport

- last_communication is updated for every received report (heartbeat behavior).
- For reports with MOF metadata:
  - status success => state Success, has_error_last_report = 0
  - any other status => state Failure, has_error_last_report = 1
- For reports without MOF metadata:
  - if report.Errors contains non-empty errors => state Failure, has_error_last_report = 1
  - otherwise, agent state is not changed.

## Update procedure

Follow these steps in order:

1. Stop the service.
2. Execute the SQL migration script:
   - db/migration_v1.1.3p2.sql
3. Overwrite existing files with files from the release ZIP.
4. Start the service.

## Post-update checks (recommended)

- Verify dsc_infra_info.db_version is 1.1.3p2.
- Verify scheduler page actions render normally.
- Verify node status behavior:
  - MOF success => OK
  - MOF non-success => KO
  - no MOF + errors => KO
  - no MOF + no errors => unchanged
