### PR TITLE
V1.1.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           xcopy db release\db /E /I
           xcopy web release\web /E /I
           xcopy templates release\templates /E /I
+          xcopy scripts release\scripts /E /I
 
       - name: Zip Admin Console
         run: |

--- a/db/migration_v1.1.4.sql
+++ b/db/migration_v1.1.4.sql
@@ -1,0 +1,4 @@
+IF EXISTS (SELECT 1 FROM dsc_infra_info WHERE id = 1)
+	UPDATE dsc_infra_info SET db_version = '1.1.4', updated_at = GETDATE() WHERE id = 1;
+ELSE
+	INSERT INTO dsc_infra_info (id, web_version, db_version, updated_at) VALUES (1, '0.0.1', '1.1.4', GETDATE());

--- a/doc/APIv1.md
+++ b/doc/APIv1.md
@@ -82,6 +82,11 @@ Both JWT and API tokens grant access to the API according to the user's permissi
 - List all agents.
 - Query params supported:
 	- `count=1`: return only the total count.
+	- `stats` (ex: `/api/v1/agents?stats`): return agent counts by status buckets:
+		- `compliant` (`state` in `success|ok`)
+		- `failed` (`state=failure`)
+		- `pending_enroll` (`state=waiting_for_registration`)
+		- `pending_apply` (`state=pending_apply`)
 	- `node_name=<name>`: filter by exact node name.
 	- `has_error_last_report=true|false`: filter by last report error status.
 	- `tag=key:value`: filter by tag.

--- a/doc/APIv1.md
+++ b/doc/APIv1.md
@@ -129,6 +129,28 @@ Both JWT and API tokens grant access to the API according to the user's permissi
 
 ---
 
+## Audit
+
+### GET `/api/v1/audit`
+- List audit rows (paginated, DataTables compatible).
+- Query params supported (combinable):
+	- `users=user1,user2` (emails)
+	- `actions=login,delete`
+	- `date_from=YYYY-MM-DDTHH:mm` (or `YYYY-MM-DD HH:mm:ss`)
+	- `date_to=YYYY-MM-DDTHH:mm` (or `YYYY-MM-DD HH:mm:ss`)
+	- DataTables params: `draw`, `start`, `length`, `search[value]`, `order[0][column]`, `order[0][dir]`
+
+### GET `/api/v1/audit/filters`
+- Returns available values for audit filter dropdowns.
+- Response shape:
+	- `users`: string[]
+	- `actions`: string[]
+
+### GET `/api/v1/audit/export`
+- Export audit rows as CSV.
+
+---
+
 ## Modules
 
 ### POST `/api/v1/modules/upload`

--- a/doc/release_v1.1.3p2.md
+++ b/doc/release_v1.1.3p2.md
@@ -1,0 +1,53 @@
+# Release v1.1.3p2
+
+Date: 2026-06-13
+
+Patch de stabilisation axe sur la securite de l interface scheduler et la logique de statut apres reception des rapports agent.
+
+## Changements
+
+### Securite
+
+- Correction d une sanitization HTML incomplete sur les attributs des boutons d action du scheduler.
+- Ajout d un echappement adapte au contexte attribut pour les valeurs injectees dans data-task.
+
+Fichier impacte:
+- web/scheduler_config.js
+
+### Comportement du statut agent apres SendReport
+
+- last_communication est mise a jour pour chaque rapport recu (heartbeat).
+- Pour les rapports avec metadata MOF:
+  - statut success => state Success, has_error_last_report = 0
+  - tout autre statut => state Failure, has_error_last_report = 1
+- Pour les rapports sans metadata MOF:
+  - si report.Errors contient des erreurs non vides => state Failure, has_error_last_report = 1
+  - sinon, l etat agent n est pas modifie.
+
+Fichier impacte:
+- handlers/sendreport.go
+
+## Base de donnees
+
+- Ajout du script de migration pour la version DB:
+  - db/migration_v1.1.3p2.sql
+
+## Procedure de mise a jour
+
+Executer ces etapes dans cet ordre:
+
+1. Arret du service.
+2. Execution du script SQL de migration:
+   - db/migration_v1.1.3p2.sql
+3. Ecrasement des fichiers existants avec ceux du ZIP de release.
+4. Demarrage du service.
+
+## Verifications post mise a jour (recommande)
+
+- Verifier que dsc_infra_info.db_version vaut 1.1.3p2.
+- Verifier que les actions de la page scheduler s affichent correctement.
+- Verifier la logique de statut noeud:
+  - MOF success => OK
+  - MOF non success => KO
+  - sans MOF + erreurs => KO
+  - sans MOF + sans erreurs => inchange

--- a/doc/release_v1.1.4.md
+++ b/doc/release_v1.1.4.md
@@ -1,0 +1,91 @@
+# Release v1.1.4
+
+Date: 2026-06-14
+
+Stabilization and UX/API improvement release, focused on the audit page, dashboard load reduction, Windows installation workflow, and startup robustness.
+
+## Changes
+
+### API and Performance
+
+- Added `GET /api/v1/agents?stats` to return consolidated counters (compliant, failed, pending_enroll, pending_apply).
+- Reduced dashboard load by using precomputed stats instead of client-side aggregations.
+
+Impacted files:
+- handlers/agent_api.go
+- web/reports.js
+- doc/APIv1.md
+
+### Audit (WebUI + API)
+
+- Added server-side DataTables ordering support (column mapping + direction).
+- Added combined filters: users, actions, date_from, date_to.
+- Aligned CSV export with active filters (same filtering logic as list endpoint).
+- Added `GET /api/v1/audit/filters` to load filter options.
+- UI adjustments for the filters bar (alignment improvements).
+
+Impacted files:
+- handlers/audit_list.go
+- internal/routes/web_routes.go
+- web/admin_audit.js
+- templates/audit.tmpl
+- doc/APIv1.md
+
+### Scheduler / Startup Robustness
+
+- Fixed handling of scheduler runs stuck in running state at startup.
+- For MSSQL, switched to typed date parameters to avoid format-sensitive implicit conversions.
+
+Impacted file:
+- internal/db/scheduler_history.go
+
+### Packaging and Windows Scripts
+
+- Added/improved scripts:
+  - `scripts/install-windows.ps1`
+  - `scripts/update-windows.ps1`
+  - `scripts/uninstall-windows.ps1`
+- Added registry metadata handling (install path, service, version) and Appwiz integration.
+- Included the `scripts/` folder in the release ZIP artifact.
+
+Impacted files:
+- scripts/install-windows.ps1
+- scripts/update-windows.ps1
+- scripts/uninstall-windows.ps1
+- .github/workflows/release.yml
+
+### UI
+
+- Style adjustments (navigation/left sidebar and active states) and improved overall visual consistency.
+
+Impacted files:
+- templates/menu.tmpl
+- web/style.css
+
+## Database
+
+- No new mandatory migration specific to v1.1.4.
+- If upgrading from a version older than v1.1.3p2, apply previously required migrations before moving to v1.1.4.
+
+## Update Procedure
+
+Run these steps in order:
+
+1. Stop the service.
+2. Back up the database and `config.json`.
+3. Replace application files with those from the v1.1.4 ZIP (including `scripts/`).
+4. If required by your version history, run missing SQL migrations.
+5. Restart the service.
+
+## Post-Update Checks (Recommended)
+
+- Verify access to `/web/admin/audit`.
+- Verify ordering/filtering/CSV export on audit.
+- Verify dashboard behavior (fast counters and chart loading).
+- Verify Windows scripts are present in the deployed package.
+- Verify startup logs and absence of critical SQL errors.
+
+## Notes
+
+- A `401` on `/api/v1/audit` indicates a missing or expired authenticated session.
+- The release check may report an older remote version depending on the publication repository state.

--- a/handlers/agent_api.go
+++ b/handlers/agent_api.go
@@ -21,6 +21,31 @@ func GetAgentsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	defer database.Close()
 
+	// Support de l'option ?stats (avec ou sans valeur), ex: /api/v1/agents?stats
+	if _, statsRequested := r.URL.Query()["stats"]; statsRequested {
+		var compliant, failed, pendingEnroll, pendingApply int
+		err := database.QueryRow(`
+			SELECT
+				SUM(CASE WHEN LOWER(COALESCE(state, '')) IN ('success', 'ok') THEN 1 ELSE 0 END) AS compliant,
+				SUM(CASE WHEN LOWER(COALESCE(state, '')) = 'failure' THEN 1 ELSE 0 END) AS failed,
+				SUM(CASE WHEN LOWER(COALESCE(state, '')) = 'waiting_for_registration' THEN 1 ELSE 0 END) AS pending_enroll,
+				SUM(CASE WHEN LOWER(COALESCE(state, '')) = 'pending_apply' THEN 1 ELSE 0 END) AS pending_apply
+			FROM agents`).Scan(&compliant, &failed, &pendingEnroll, &pendingApply)
+		if err != nil {
+			http.Error(w, "DB stats error", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]int{
+			"compliant":      compliant,
+			"failed":         failed,
+			"pending_enroll": pendingEnroll,
+			"pending_apply":  pendingApply,
+		})
+		return
+	}
+
 	       // Support de l'option ?count=1
 	       if r.URL.Query().Get("count") == "1" {
 		       var count int

--- a/handlers/audit_list.go
+++ b/handlers/audit_list.go
@@ -7,11 +7,69 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"go-dsc-pull/internal/db"
 	"go-dsc-pull/internal/global"
 	"go-dsc-pull/internal/schema"
 )
+
+func splitCSVValues(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		v := strings.TrimSpace(p)
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func parseDateParam(raw string) (time.Time, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	layouts := []string{
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04",
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func dateFilterArg(driverName string, t time.Time) interface{} {
+	if driverName == "mssql" || driverName == "sqlserver" {
+		return t.UTC()
+	}
+	return t.UTC().Format("2006-01-02 15:04:05")
+}
+
+func lowerExpr(driverName, column string) string {
+	if driverName == "mssql" || driverName == "sqlserver" {
+		return "LOWER(ISNULL(" + column + ", ''))"
+	}
+	return "LOWER(COALESCE(" + column + ", ''))"
+}
+
+func inClause(field string, count int) string {
+	if count <= 0 {
+		return ""
+	}
+	placeholders := make([]string, count)
+	for i := range placeholders {
+		placeholders[i] = "?"
+	}
+	return field + " IN (" + strings.Join(placeholders, ",") + ")"
+}
 
 func auditSearchClause(driverName string) string {
 	if driverName == "mssql" || driverName == "sqlserver" {
@@ -84,6 +142,51 @@ func AuditListHandler(w http.ResponseWriter, r *http.Request) {
 		search = strings.TrimSpace(r.URL.Query().Get("search"))
 	}
 
+	users := splitCSVValues(r.URL.Query().Get("users"))
+	actions := splitCSVValues(r.URL.Query().Get("actions"))
+
+	dateFrom, hasDateFrom := parseDateParam(r.URL.Query().Get("date_from"))
+	if raw := strings.TrimSpace(r.URL.Query().Get("date_from")); raw != "" && !hasDateFrom {
+		http.Error(w, "Invalid date_from", http.StatusBadRequest)
+		return
+	}
+	dateTo, hasDateTo := parseDateParam(r.URL.Query().Get("date_to"))
+	if raw := strings.TrimSpace(r.URL.Query().Get("date_to")); raw != "" && !hasDateTo {
+		http.Error(w, "Invalid date_to", http.StatusBadRequest)
+		return
+	}
+
+	orderBy := "created_at"
+	orderDir := "DESC"
+	orderColumn := r.URL.Query().Get("order[0][column]")
+	if orderColumn == "" {
+		orderColumn = r.URL.Query().Get("orderColumn")
+	}
+	if orderColumn != "" {
+		switch orderColumn {
+		case "0":
+			orderBy = "user_email"
+		case "1":
+			orderBy = "action"
+		case "2":
+			orderBy = "target"
+		case "3":
+			orderBy = "details"
+		case "4":
+			orderBy = "created_at"
+		}
+	}
+
+	orderDirParam := r.URL.Query().Get("order[0][dir]")
+	if orderDirParam == "" {
+		orderDirParam = r.URL.Query().Get("orderDir")
+	}
+	if strings.EqualFold(orderDirParam, "asc") {
+		orderDir = "ASC"
+	}
+
+	orderClause := fmt.Sprintf(" ORDER BY %s %s", orderBy, orderDir)
+
 	database, err := db.OpenDB(&global.AppConfig.Database)
 	if err != nil {
 		http.Error(w, "DB open error", http.StatusInternalServerError)
@@ -98,13 +201,42 @@ func AuditListHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filteredTotal := total
-	whereClause := ""
+	whereParts := make([]string, 0)
 	filterArgs := make([]interface{}, 0)
+	driverName := global.AppConfig.Database.Driver
+
+	if len(users) > 0 {
+		whereParts = append(whereParts, inClause(lowerExpr(driverName, "user_email"), len(users)))
+		for _, u := range users {
+			filterArgs = append(filterArgs, strings.ToLower(u))
+		}
+	}
+
+	if len(actions) > 0 {
+		whereParts = append(whereParts, inClause(lowerExpr(driverName, "action"), len(actions)))
+		for _, a := range actions {
+			filterArgs = append(filterArgs, strings.ToLower(a))
+		}
+	}
+
+	if hasDateFrom {
+		whereParts = append(whereParts, "created_at >= ?")
+		filterArgs = append(filterArgs, dateFilterArg(driverName, dateFrom))
+	}
+	if hasDateTo {
+		whereParts = append(whereParts, "created_at <= ?")
+		filterArgs = append(filterArgs, dateFilterArg(driverName, dateTo))
+	}
+
 	if search != "" {
 		like := "%" + strings.ToLower(search) + "%"
-		whereClause = auditSearchClause(global.AppConfig.Database.Driver)
-		filterArgs = []interface{}{like, like, like, like, like}
+		whereParts = append(whereParts, strings.TrimPrefix(auditSearchClause(driverName), " WHERE "))
+		filterArgs = append(filterArgs, like, like, like, like, like)
+	}
 
+	whereClause := ""
+	if len(whereParts) > 0 {
+		whereClause = " WHERE " + strings.Join(whereParts, " AND ")
 		countQuery := "SELECT COUNT(*) FROM audit" + whereClause
 		if err := database.QueryRow(countQuery, filterArgs...).Scan(&filteredTotal); err != nil {
 			http.Error(w, "DB filtered count error", http.StatusInternalServerError)
@@ -112,10 +244,10 @@ func AuditListHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	query := "SELECT id, user_email, action, target, details, ip_address, created_at FROM audit" + whereClause + " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+	query := "SELECT id, user_email, action, target, details, ip_address, created_at FROM audit" + whereClause + orderClause + " LIMIT ? OFFSET ?"
 	args := append(filterArgs, limit+1, offset)
 	if global.AppConfig.Database.Driver == "mssql" || global.AppConfig.Database.Driver == "sqlserver" {
-		query = fmt.Sprintf("SELECT id, user_email, action, target, details, ip_address, created_at FROM audit%s ORDER BY created_at DESC OFFSET ? ROWS FETCH NEXT ? ROWS ONLY", whereClause)
+		query = fmt.Sprintf("SELECT id, user_email, action, target, details, ip_address, created_at FROM audit%s%s OFFSET ? ROWS FETCH NEXT ? ROWS ONLY", whereClause, orderClause)
 		args = append(filterArgs, offset, limit+1)
 	}
 
@@ -157,6 +289,50 @@ func AuditListHandler(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(payload)
 }
 
+// AuditFilterOptionsHandler returns distinct users/actions for audit filters.
+func AuditFilterOptionsHandler(w http.ResponseWriter, r *http.Request) {
+	database, err := db.OpenDB(&global.AppConfig.Database)
+	if err != nil {
+		http.Error(w, "DB open error", http.StatusInternalServerError)
+		return
+	}
+	defer database.Close()
+
+	users := make([]string, 0)
+	userRows, err := database.Query("SELECT DISTINCT user_email FROM audit WHERE user_email IS NOT NULL AND user_email <> '' ORDER BY user_email")
+	if err != nil {
+		http.Error(w, "DB query error", http.StatusInternalServerError)
+		return
+	}
+	for userRows.Next() {
+		var v string
+		if err := userRows.Scan(&v); err == nil {
+			users = append(users, v)
+		}
+	}
+	userRows.Close()
+
+	actions := make([]string, 0)
+	actionRows, err := database.Query("SELECT DISTINCT action FROM audit WHERE action IS NOT NULL AND action <> '' ORDER BY action")
+	if err != nil {
+		http.Error(w, "DB query error", http.StatusInternalServerError)
+		return
+	}
+	for actionRows.Next() {
+		var v string
+		if err := actionRows.Scan(&v); err == nil {
+			actions = append(actions, v)
+		}
+	}
+	actionRows.Close()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"users":   users,
+		"actions": actions,
+	})
+}
+
 // AuditExportCSVHandler exports audit rows as CSV and applies optional search filter.
 func AuditExportCSVHandler(w http.ResponseWriter, r *http.Request) {
 	database, err := db.OpenDB(&global.AppConfig.Database)
@@ -167,12 +343,56 @@ func AuditExportCSVHandler(w http.ResponseWriter, r *http.Request) {
 	defer database.Close()
 
 	search := strings.TrimSpace(r.URL.Query().Get("search"))
-	whereClause := ""
+	users := splitCSVValues(r.URL.Query().Get("users"))
+	actions := splitCSVValues(r.URL.Query().Get("actions"))
+
+	dateFrom, hasDateFrom := parseDateParam(r.URL.Query().Get("date_from"))
+	if raw := strings.TrimSpace(r.URL.Query().Get("date_from")); raw != "" && !hasDateFrom {
+		http.Error(w, "Invalid date_from", http.StatusBadRequest)
+		return
+	}
+	dateTo, hasDateTo := parseDateParam(r.URL.Query().Get("date_to"))
+	if raw := strings.TrimSpace(r.URL.Query().Get("date_to")); raw != "" && !hasDateTo {
+		http.Error(w, "Invalid date_to", http.StatusBadRequest)
+		return
+	}
+
+	whereParts := make([]string, 0)
 	args := make([]interface{}, 0)
+	driverName := global.AppConfig.Database.Driver
+
+	if len(users) > 0 {
+		whereParts = append(whereParts, inClause(lowerExpr(driverName, "user_email"), len(users)))
+		for _, u := range users {
+			args = append(args, strings.ToLower(u))
+		}
+	}
+
+	if len(actions) > 0 {
+		whereParts = append(whereParts, inClause(lowerExpr(driverName, "action"), len(actions)))
+		for _, a := range actions {
+			args = append(args, strings.ToLower(a))
+		}
+	}
+
+	if hasDateFrom {
+		whereParts = append(whereParts, "created_at >= ?")
+		args = append(args, dateFilterArg(driverName, dateFrom))
+	}
+	if hasDateTo {
+		whereParts = append(whereParts, "created_at <= ?")
+		args = append(args, dateFilterArg(driverName, dateTo))
+	}
+
 	if search != "" {
 		like := "%" + strings.ToLower(search) + "%"
-		whereClause = auditSearchClause(global.AppConfig.Database.Driver)
-		args = []interface{}{like, like, like, like, like}
+		whereParts = append(whereParts, strings.TrimPrefix(auditSearchClause(driverName), " WHERE "))
+		args = append(args, like, like, like, like, like)
+	}
+
+	whereClause := ""
+	if len(whereParts) > 0 {
+		whereClause = " WHERE " + strings.Join(whereParts, " AND ")
 	}
 
 	query := "SELECT user_email, action, target, details, created_at FROM audit" + whereClause + " ORDER BY created_at DESC"

--- a/handlers/sendreport.go
+++ b/handlers/sendreport.go
@@ -112,18 +112,7 @@ func SendReportHandler(w http.ResponseWriter, r *http.Request) {
 				log.Printf("[SENDREPORT] Erreur update last_communication: %v", err)
 			}
 
-			hasReportErrors := false
-			for _, reportErr := range report.Errors {
-				errText := strings.TrimSpace(reportErr)
-				if errText != "" && errText != "[]" && errText != "{}" && strings.ToLower(errText) != "null" {
-					hasReportErrors = true
-					break
-				}
-			}
 
-			// Regle metier:
-			// - MOF: success => OK, tout autre statut => KO
-			// - Sans MOF: erreurs explicites => KO, sinon ne pas modifier l etat
 			if mofApplied == 1 {
 				hasError := 1
 				state := "Failure"
@@ -134,11 +123,6 @@ func SendReportHandler(w http.ResponseWriter, r *http.Request) {
 				_, err = database.Exec("UPDATE agents SET has_error_last_report = ?, state = ? WHERE agent_id = ?", hasError, state, agentId)
 				if err != nil {
 					log.Printf("[SENDREPORT] Erreur update has_error_last_report/state: %v", err)
-				}
-			} else if hasReportErrors {
-				_, err = database.Exec("UPDATE agents SET has_error_last_report = ?, state = ? WHERE agent_id = ?", 1, "Failure", agentId)
-				if err != nil {
-					log.Printf("[SENDREPORT] Erreur update has_error_last_report/state (no MOF + errors): %v", err)
 				}
 			} else {
 				log.Printf("[SENDREPORT] Rapport ignore pour l etat web (mof_applied=0): agent_id=%s, job_id=%s, operation_type=%s", agentId, report.JobId, report.OperationType)

--- a/internal/db/scheduler_history.go
+++ b/internal/db/scheduler_history.go
@@ -264,6 +264,7 @@ func CancelRunningSchedulerTasks(db *sql.DB, driver string, cancelledAt time.Tim
 	}
 
 	finished := formatTS(cancelledAt)
+	finishedMSSQL := cancelledAt.UTC()
 	driver = strings.ToLower(driver)
 
 	var result sql.Result
@@ -273,7 +274,7 @@ func CancelRunningSchedulerTasks(db *sql.DB, driver string, cancelledAt time.Tim
 UPDATE scheduler_task_runs
 SET finished_at = ?, status = 'cancelled', message = CASE WHEN message IS NULL OR LTRIM(RTRIM(message)) = '' THEN ? ELSE message END
 WHERE status = 'running'
-`, finished, message)
+`, finishedMSSQL, message)
 	} else {
 		result, err = db.Exec(`
 UPDATE scheduler_task_runs

--- a/internal/routes/web_routes.go
+++ b/internal/routes/web_routes.go
@@ -187,5 +187,6 @@ func RegisterWebRoutes(mux *http.ServeMux, dbConn *sql.DB, jwtAuthMiddleware fun
 	mux.Handle("DELETE /api/v1/agents/{id}", jwtAuthMiddleware(http.HandlerFunc(handlers.DeleteNodeHandler)))
 	mux.Handle("/web/admin/audit",handlers.WebJWTAuthMiddleware(middleware.WebAdminOnly(dbConn, renderDenied)(http.HandlerFunc(handlers.WebAuditHandler))))
 	mux.Handle("GET /api/v1/audit", jwtAuthMiddleware(adminOnly(http.HandlerFunc(handlers.AuditListHandler))))
+	mux.Handle("GET /api/v1/audit/filters", jwtAuthMiddleware(adminOnly(http.HandlerFunc(handlers.AuditFilterOptionsHandler))))
 	mux.Handle("GET /api/v1/audit/export", jwtAuthMiddleware(adminOnly(http.HandlerFunc(handlers.AuditExportCSVHandler))))
 }

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,0 +1,129 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SourcePath,
+
+    [string]$InstallPath = "$env:ProgramFiles\DSC-Admin-Console",
+    [string]$RegistryKeyPath = "HKLM:\SOFTWARE\go-dsc-pull\DSC-Admin-Console",
+    [string]$ExeName = "DSC-Admin-Console.exe",
+    [string]$ServiceName = "DSCAdminConsole",
+    [switch]$CreateService,
+    [switch]$OverwriteConfig
+)
+
+$ErrorActionPreference = "Stop"
+
+function Assert-Admin {
+    $currentIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($currentIdentity)
+    if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw "Ce script doit etre execute en tant qu administrateur."
+    }
+}
+
+function Resolve-AbsolutePath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return (Resolve-Path -Path $Path).Path
+}
+
+function Copy-DirectoryContent {
+    param(
+        [Parameter(Mandatory = $true)][string]$From,
+        [Parameter(Mandatory = $true)][string]$To,
+        [switch]$SkipConfig
+    )
+
+    if (-not (Test-Path -Path $To)) {
+        New-Item -ItemType Directory -Path $To -Force | Out-Null
+    }
+
+    Get-ChildItem -Path $From -Force | ForEach-Object {
+        if ($SkipConfig -and $_.PSIsContainer -eq $false -and $_.Name -ieq "config.json") {
+            return
+        }
+        Copy-Item -Path $_.FullName -Destination $To -Recurse -Force
+    }
+}
+
+function Ensure-RegistryInstallPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$KeyPath,
+        [Parameter(Mandatory = $true)][string]$PathValue,
+        [string]$VersionValue,
+        [string]$ServiceNameValue
+    )
+
+    if (-not (Test-Path -Path $KeyPath)) {
+        New-Item -Path $KeyPath -Force | Out-Null
+    }
+
+    New-ItemProperty -Path $KeyPath -Name "InstallPath" -PropertyType String -Value $PathValue -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "InstalledAtUtc" -PropertyType String -Value ((Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")) -Force | Out-Null
+    if ($ServiceNameValue) {
+        New-ItemProperty -Path $KeyPath -Name "ServiceName" -PropertyType String -Value $ServiceNameValue -Force | Out-Null
+    }
+    if ($VersionValue) {
+        New-ItemProperty -Path $KeyPath -Name "Version" -PropertyType String -Value $VersionValue -Force | Out-Null
+    }
+}
+
+function Ensure-Service {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$BinaryPath
+    )
+
+    $existing = Get-Service -Name $Name -ErrorAction SilentlyContinue
+    $binPathWithQuotes = '"' + $BinaryPath + '"'
+
+    if ($null -eq $existing) {
+        New-Service -Name $Name -BinaryPathName $binPathWithQuotes -DisplayName $Name -StartupType Automatic | Out-Null
+        Write-Host "Service cree: $Name"
+    }
+    else {
+        & sc.exe config $Name binPath= $binPathWithQuotes start= auto | Out-Null
+        Write-Host "Service mis a jour: $Name"
+    }
+}
+
+Assert-Admin
+
+$source = Resolve-AbsolutePath -Path $SourcePath
+if (-not (Test-Path -Path $source -PathType Container)) {
+    throw "SourcePath invalide: $SourcePath"
+}
+
+$expectedExe = Join-Path $source $ExeName
+if (-not (Test-Path -Path $expectedExe -PathType Leaf)) {
+    throw "Executable introuvable dans la source: $expectedExe"
+}
+
+$resolvedInstallPath = [System.IO.Path]::GetFullPath($InstallPath)
+if (-not (Test-Path -Path $resolvedInstallPath)) {
+    New-Item -ItemType Directory -Path $resolvedInstallPath -Force | Out-Null
+}
+
+$skipConfig = $false
+if ((Test-Path -Path (Join-Path $resolvedInstallPath "config.json")) -and (-not $OverwriteConfig)) {
+    $skipConfig = $true
+}
+
+Copy-DirectoryContent -From $source -To $resolvedInstallPath -SkipConfig:$skipConfig
+
+$installedExePath = Join-Path $resolvedInstallPath $ExeName
+$version = $null
+if (Test-Path -Path $installedExePath -PathType Leaf) {
+    $version = (Get-Item -Path $installedExePath).VersionInfo.ProductVersion
+}
+
+Ensure-RegistryInstallPath -KeyPath $RegistryKeyPath -PathValue $resolvedInstallPath -VersionValue $version -ServiceNameValue $ServiceName
+
+if ($CreateService) {
+    Ensure-Service -Name $ServiceName -BinaryPath $installedExePath
+}
+
+Write-Host "Installation terminee."
+Write-Host "InstallPath enregistre dans le registre: $resolvedInstallPath"
+Write-Host "ServiceName enregistre dans le registre: $ServiceName"
+if ($skipConfig) {
+    Write-Host "config.json existant conserve (utiliser -OverwriteConfig pour l ecraser)."
+}

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -11,6 +11,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$AppwizUninstallKeyPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\DSC-Admin-Console"
 
 function Assert-Admin {
     $currentIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
@@ -85,6 +86,41 @@ function Ensure-Service {
     }
 }
 
+function Ensure-AppwizUninstallEntry {
+    param(
+        [Parameter(Mandatory = $true)][string]$KeyPath,
+        [Parameter(Mandatory = $true)][string]$InstallPathValue,
+        [Parameter(Mandatory = $true)][string]$ExePath,
+        [Parameter(Mandatory = $true)][string]$ServiceNameValue,
+        [string]$VersionValue
+    )
+
+    if (-not (Test-Path -Path $KeyPath)) {
+        New-Item -Path $KeyPath -Force | Out-Null
+    }
+
+    $displayVersion = if ([string]::IsNullOrWhiteSpace($VersionValue)) { "Unknown" } else { $VersionValue }
+    $uninstallScriptPath = Join-Path $InstallPathValue "scripts\uninstall-windows.ps1"
+    $uninstallCmd = "powershell.exe -ExecutionPolicy Bypass -File `"$uninstallScriptPath`" -InstallPath `"$InstallPathValue`" -ServiceName `"$ServiceNameValue`""
+    $quietUninstallCmd = $uninstallCmd + " -Force"
+
+    $estimatedSizeKb = 0
+    if (Test-Path -Path $InstallPathValue -PathType Container) {
+        $estimatedSizeKb = [int]([Math]::Round(((Get-ChildItem -Path $InstallPathValue -Recurse -Force -File | Measure-Object -Property Length -Sum).Sum / 1KB), 0))
+    }
+
+    New-ItemProperty -Path $KeyPath -Name "DisplayName" -PropertyType String -Value "DSC Admin Console" -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "DisplayVersion" -PropertyType String -Value $displayVersion -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "Publisher" -PropertyType String -Value "go-dsc-pull" -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "InstallLocation" -PropertyType String -Value $InstallPathValue -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "DisplayIcon" -PropertyType String -Value $ExePath -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "UninstallString" -PropertyType String -Value $uninstallCmd -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "QuietUninstallString" -PropertyType String -Value $quietUninstallCmd -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "NoModify" -PropertyType DWord -Value 1 -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "NoRepair" -PropertyType DWord -Value 1 -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "EstimatedSize" -PropertyType DWord -Value $estimatedSizeKb -Force | Out-Null
+}
+
 Assert-Admin
 
 $source = Resolve-AbsolutePath -Path $SourcePath
@@ -116,6 +152,7 @@ if (Test-Path -Path $installedExePath -PathType Leaf) {
 }
 
 Ensure-RegistryInstallPath -KeyPath $RegistryKeyPath -PathValue $resolvedInstallPath -VersionValue $version -ServiceNameValue $ServiceName
+Ensure-AppwizUninstallEntry -KeyPath $AppwizUninstallKeyPath -InstallPathValue $resolvedInstallPath -ExePath $installedExePath -ServiceNameValue $ServiceName -VersionValue $version
 
 if ($CreateService) {
     Ensure-Service -Name $ServiceName -BinaryPath $installedExePath
@@ -124,6 +161,7 @@ if ($CreateService) {
 Write-Host "Installation terminee."
 Write-Host "InstallPath enregistre dans le registre: $resolvedInstallPath"
 Write-Host "ServiceName enregistre dans le registre: $ServiceName"
+Write-Host "Entree Appwiz enregistree: $AppwizUninstallKeyPath"
 if ($skipConfig) {
     Write-Host "config.json existant conserve (utiliser -OverwriteConfig pour l ecraser)."
 }

--- a/scripts/uninstall-windows.ps1
+++ b/scripts/uninstall-windows.ps1
@@ -1,0 +1,111 @@
+param(
+    [string]$InstallPath,
+    [string]$RegistryKeyPath = "HKLM:\SOFTWARE\go-dsc-pull\DSC-Admin-Console",
+    [string]$AppwizUninstallKeyPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\DSC-Admin-Console",
+    [string]$ServiceName,
+    [switch]$Force,
+    [switch]$KeepConfig
+)
+
+$ErrorActionPreference = "Stop"
+
+function Assert-Admin {
+    $currentIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($currentIdentity)
+    if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw "Ce script doit etre execute en tant qu administrateur."
+    }
+}
+
+function Get-RegistryValueOrNull {
+    param(
+        [Parameter(Mandatory = $true)][string]$KeyPath,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if (-not (Test-Path -Path $KeyPath)) {
+        return $null
+    }
+
+    try {
+        $props = Get-ItemProperty -Path $KeyPath -ErrorAction Stop
+        return $props.$Name
+    }
+    catch {
+        return $null
+    }
+}
+
+function Stop-AndDeleteServiceIfExists {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        return
+    }
+
+    $svc = Get-Service -Name $Name -ErrorAction SilentlyContinue
+    if ($null -eq $svc) {
+        Write-Host "Service non trouve: $Name"
+        return
+    }
+
+    if ($svc.Status -ne 'Stopped') {
+        Stop-Service -Name $Name -Force
+        $svc.WaitForStatus('Stopped', [TimeSpan]::FromSeconds(60))
+        Write-Host "Service arrete: $Name"
+    }
+
+    & sc.exe delete $Name | Out-Null
+    Write-Host "Service supprime: $Name"
+}
+
+Assert-Admin
+
+if ([string]::IsNullOrWhiteSpace($InstallPath)) {
+    $InstallPath = Get-RegistryValueOrNull -KeyPath $RegistryKeyPath -Name "InstallPath"
+}
+
+if ([string]::IsNullOrWhiteSpace($ServiceName)) {
+    $ServiceName = Get-RegistryValueOrNull -KeyPath $RegistryKeyPath -Name "ServiceName"
+}
+
+if ([string]::IsNullOrWhiteSpace($ServiceName)) {
+    $ServiceName = "DSCAdminConsole"
+}
+
+if (-not $Force) {
+    $target = if ([string]::IsNullOrWhiteSpace($InstallPath)) { "l installation" } else { $InstallPath }
+    $answer = Read-Host "Confirmer la desinstallation de $target ? (O/N)"
+    if ($answer -notin @("O", "o", "Y", "y")) {
+        Write-Host "Desinstallation annulee."
+        exit 0
+    }
+}
+
+Stop-AndDeleteServiceIfExists -Name $ServiceName
+
+if (-not [string]::IsNullOrWhiteSpace($InstallPath) -and (Test-Path -Path $InstallPath -PathType Container)) {
+    if ($KeepConfig -and (Test-Path -Path (Join-Path $InstallPath "config.json") -PathType Leaf)) {
+        $backupDir = Join-Path $env:ProgramData "go-dsc-pull"
+        if (-not (Test-Path -Path $backupDir)) {
+            New-Item -Path $backupDir -ItemType Directory -Force | Out-Null
+        }
+        Copy-Item -Path (Join-Path $InstallPath "config.json") -Destination (Join-Path $backupDir "config.json") -Force
+        Write-Host "config.json sauvegarde dans: $backupDir\\config.json"
+    }
+
+    Remove-Item -Path $InstallPath -Recurse -Force
+    Write-Host "Dossier supprime: $InstallPath"
+}
+
+if (Test-Path -Path $RegistryKeyPath) {
+    Remove-Item -Path $RegistryKeyPath -Recurse -Force
+    Write-Host "Cle registre supprimee: $RegistryKeyPath"
+}
+
+if (Test-Path -Path $AppwizUninstallKeyPath) {
+    Remove-Item -Path $AppwizUninstallKeyPath -Recurse -Force
+    Write-Host "Entree Appwiz supprimee: $AppwizUninstallKeyPath"
+}
+
+Write-Host "Desinstallation terminee."

--- a/scripts/update-windows.ps1
+++ b/scripts/update-windows.ps1
@@ -1,0 +1,228 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SourcePath,
+
+    [string]$InstallPath,
+    [string]$RegistryKeyPath = "HKLM:\SOFTWARE\go-dsc-pull\DSC-Admin-Console",
+    [string]$ExeName = "DSC-Admin-Console.exe",
+    [string]$ServiceName = "DSCAdminConsole",
+    [string]$MigrationScriptPath,
+    [switch]$RunMigration,
+    [switch]$OverwriteConfig,
+    [switch]$NoServiceRestart
+)
+
+$ErrorActionPreference = "Stop"
+
+function Assert-Admin {
+    $currentIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($currentIdentity)
+    if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw "Ce script doit etre execute en tant qu administrateur."
+    }
+}
+
+function Resolve-AbsolutePath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return (Resolve-Path -Path $Path).Path
+}
+
+function Get-InstallPathFromRegistry {
+    param([Parameter(Mandatory = $true)][string]$KeyPath)
+
+    if (-not (Test-Path -Path $KeyPath)) {
+        return $null
+    }
+
+    $props = Get-ItemProperty -Path $KeyPath -ErrorAction Stop
+    return $props.InstallPath
+}
+
+function Get-ServiceNameFromRegistry {
+    param([Parameter(Mandatory = $true)][string]$KeyPath)
+
+    if (-not (Test-Path -Path $KeyPath)) {
+        return $null
+    }
+
+    $props = Get-ItemProperty -Path $KeyPath -ErrorAction Stop
+    return $props.ServiceName
+}
+
+function Copy-DirectoryContent {
+    param(
+        [Parameter(Mandatory = $true)][string]$From,
+        [Parameter(Mandatory = $true)][string]$To,
+        [switch]$SkipConfig
+    )
+
+    if (-not (Test-Path -Path $To)) {
+        throw "InstallPath introuvable: $To"
+    }
+
+    Get-ChildItem -Path $From -Force | ForEach-Object {
+        if ($SkipConfig -and $_.PSIsContainer -eq $false -and $_.Name -ieq "config.json") {
+            return
+        }
+        Copy-Item -Path $_.FullName -Destination $To -Recurse -Force
+    }
+}
+
+function Stop-AppServiceIfExists {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $svc = Get-Service -Name $Name -ErrorAction SilentlyContinue
+    if ($null -eq $svc) {
+        Write-Host "Service non trouve, poursuite sans arret: $Name"
+        return $false
+    }
+
+    if ($svc.Status -ne 'Stopped') {
+        Stop-Service -Name $Name -Force
+        $svc.WaitForStatus('Stopped', [TimeSpan]::FromSeconds(60))
+    }
+
+    Write-Host "Service arrete: $Name"
+    return $true
+}
+
+function Start-AppServiceIfExists {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $svc = Get-Service -Name $Name -ErrorAction SilentlyContinue
+    if ($null -eq $svc) {
+        Write-Host "Service non trouve, aucun redemarrage: $Name"
+        return
+    }
+
+    Start-Service -Name $Name
+    $svc.Refresh()
+    Write-Host "Service demarre: $Name"
+}
+
+function Run-MssqlMigrationFromConfig {
+    param(
+        [Parameter(Mandatory = $true)][string]$ConfigPath,
+        [Parameter(Mandatory = $true)][string]$SqlPath
+    )
+
+    if (-not (Test-Path -Path $ConfigPath -PathType Leaf)) {
+        throw "config.json introuvable: $ConfigPath"
+    }
+
+    if (-not (Test-Path -Path $SqlPath -PathType Leaf)) {
+        throw "Script SQL introuvable: $SqlPath"
+    }
+
+    $sqlcmd = Get-Command sqlcmd -ErrorAction SilentlyContinue
+    if ($null -eq $sqlcmd) {
+        throw "sqlcmd n est pas disponible."
+    }
+
+    $cfg = Get-Content -Raw -Path $ConfigPath | ConvertFrom-Json
+    if ($null -eq $cfg.database -or [string]::IsNullOrWhiteSpace($cfg.database.driver)) {
+        throw "Configuration database invalide dans config.json"
+    }
+
+    if ($cfg.database.driver.ToLowerInvariant() -ne "mssql") {
+        throw "Migration automatique supportee uniquement pour le driver mssql."
+    }
+
+    $server = "{0},{1}" -f $cfg.database.server, $cfg.database.port
+    & $sqlcmd.Source -S $server -d $cfg.database.name -U $cfg.database.user -P $cfg.database.password -b -i $SqlPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "Echec execution migration SQL."
+    }
+
+    Write-Host "Migration SQL executee: $SqlPath"
+}
+
+function Update-RegistryMetadata {
+    param(
+        [Parameter(Mandatory = $true)][string]$KeyPath,
+        [Parameter(Mandatory = $true)][string]$PathValue,
+        [string]$VersionValue,
+        [string]$ServiceNameValue
+    )
+
+    if (-not (Test-Path -Path $KeyPath)) {
+        New-Item -Path $KeyPath -Force | Out-Null
+    }
+
+    New-ItemProperty -Path $KeyPath -Name "InstallPath" -PropertyType String -Value $PathValue -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "UpdatedAtUtc" -PropertyType String -Value ((Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")) -Force | Out-Null
+    if ($ServiceNameValue) {
+        New-ItemProperty -Path $KeyPath -Name "ServiceName" -PropertyType String -Value $ServiceNameValue -Force | Out-Null
+    }
+    if ($VersionValue) {
+        New-ItemProperty -Path $KeyPath -Name "Version" -PropertyType String -Value $VersionValue -Force | Out-Null
+    }
+}
+
+Assert-Admin
+
+$source = Resolve-AbsolutePath -Path $SourcePath
+if (-not (Test-Path -Path $source -PathType Container)) {
+    throw "SourcePath invalide: $SourcePath"
+}
+
+if ([string]::IsNullOrWhiteSpace($InstallPath)) {
+    $InstallPath = Get-InstallPathFromRegistry -KeyPath $RegistryKeyPath
+}
+
+if (-not $PSBoundParameters.ContainsKey('ServiceName')) {
+    $serviceNameFromRegistry = Get-ServiceNameFromRegistry -KeyPath $RegistryKeyPath
+    if (-not [string]::IsNullOrWhiteSpace($serviceNameFromRegistry)) {
+        $ServiceName = $serviceNameFromRegistry
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($InstallPath)) {
+    throw "InstallPath manquant et aucune valeur trouvee dans le registre ($RegistryKeyPath)."
+}
+
+$resolvedInstallPath = [System.IO.Path]::GetFullPath($InstallPath)
+$serviceWasHandled = $false
+
+if (-not $NoServiceRestart) {
+    $serviceWasHandled = Stop-AppServiceIfExists -Name $ServiceName
+}
+
+try {
+    if ($RunMigration) {
+        if ([string]::IsNullOrWhiteSpace($MigrationScriptPath)) {
+            throw "-RunMigration requiert -MigrationScriptPath."
+        }
+
+        $migrationPath = if ([System.IO.Path]::IsPathRooted($MigrationScriptPath)) { $MigrationScriptPath } else { Join-Path $source $MigrationScriptPath }
+        $migrationPath = Resolve-AbsolutePath -Path $migrationPath
+        $configPath = Join-Path $resolvedInstallPath "config.json"
+        Run-MssqlMigrationFromConfig -ConfigPath $configPath -SqlPath $migrationPath
+    }
+
+    $skipConfig = $false
+    if ((Test-Path -Path (Join-Path $resolvedInstallPath "config.json")) -and (-not $OverwriteConfig)) {
+        $skipConfig = $true
+    }
+
+    Copy-DirectoryContent -From $source -To $resolvedInstallPath -SkipConfig:$skipConfig
+
+    $installedExePath = Join-Path $resolvedInstallPath $ExeName
+    $version = $null
+    if (Test-Path -Path $installedExePath -PathType Leaf) {
+        $version = (Get-Item -Path $installedExePath).VersionInfo.ProductVersion
+    }
+    Update-RegistryMetadata -KeyPath $RegistryKeyPath -PathValue $resolvedInstallPath -VersionValue $version -ServiceNameValue $ServiceName
+
+    Write-Host "Mise a jour terminee."
+    Write-Host "InstallPath registre: $resolvedInstallPath"
+    Write-Host "ServiceName registre: $ServiceName"
+    if ($skipConfig) {
+        Write-Host "config.json existant conserve (utiliser -OverwriteConfig pour l ecraser)."
+    }
+}
+finally {
+    if (-not $NoServiceRestart -and $serviceWasHandled) {
+        Start-AppServiceIfExists -Name $ServiceName
+    }
+}

--- a/scripts/update-windows.ps1
+++ b/scripts/update-windows.ps1
@@ -13,6 +13,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$AppwizUninstallKeyPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\DSC-Admin-Console"
 
 function Assert-Admin {
     $currentIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
@@ -159,6 +160,41 @@ function Update-RegistryMetadata {
     }
 }
 
+function Ensure-AppwizUninstallEntry {
+    param(
+        [Parameter(Mandatory = $true)][string]$KeyPath,
+        [Parameter(Mandatory = $true)][string]$InstallPathValue,
+        [Parameter(Mandatory = $true)][string]$ExePath,
+        [Parameter(Mandatory = $true)][string]$ServiceNameValue,
+        [string]$VersionValue
+    )
+
+    if (-not (Test-Path -Path $KeyPath)) {
+        New-Item -Path $KeyPath -Force | Out-Null
+    }
+
+    $displayVersion = if ([string]::IsNullOrWhiteSpace($VersionValue)) { "Unknown" } else { $VersionValue }
+    $uninstallScriptPath = Join-Path $InstallPathValue "scripts\uninstall-windows.ps1"
+    $uninstallCmd = "powershell.exe -ExecutionPolicy Bypass -File `"$uninstallScriptPath`" -InstallPath `"$InstallPathValue`" -ServiceName `"$ServiceNameValue`""
+    $quietUninstallCmd = $uninstallCmd + " -Force"
+
+    $estimatedSizeKb = 0
+    if (Test-Path -Path $InstallPathValue -PathType Container) {
+        $estimatedSizeKb = [int]([Math]::Round(((Get-ChildItem -Path $InstallPathValue -Recurse -Force -File | Measure-Object -Property Length -Sum).Sum / 1KB), 0))
+    }
+
+    New-ItemProperty -Path $KeyPath -Name "DisplayName" -PropertyType String -Value "DSC Admin Console" -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "DisplayVersion" -PropertyType String -Value $displayVersion -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "Publisher" -PropertyType String -Value "go-dsc-pull" -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "InstallLocation" -PropertyType String -Value $InstallPathValue -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "DisplayIcon" -PropertyType String -Value $ExePath -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "UninstallString" -PropertyType String -Value $uninstallCmd -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "QuietUninstallString" -PropertyType String -Value $quietUninstallCmd -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "NoModify" -PropertyType DWord -Value 1 -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "NoRepair" -PropertyType DWord -Value 1 -Force | Out-Null
+    New-ItemProperty -Path $KeyPath -Name "EstimatedSize" -PropertyType DWord -Value $estimatedSizeKb -Force | Out-Null
+}
+
 Assert-Admin
 
 $source = Resolve-AbsolutePath -Path $SourcePath
@@ -213,10 +249,12 @@ try {
         $version = (Get-Item -Path $installedExePath).VersionInfo.ProductVersion
     }
     Update-RegistryMetadata -KeyPath $RegistryKeyPath -PathValue $resolvedInstallPath -VersionValue $version -ServiceNameValue $ServiceName
+    Ensure-AppwizUninstallEntry -KeyPath $AppwizUninstallKeyPath -InstallPathValue $resolvedInstallPath -ExePath $installedExePath -ServiceNameValue $ServiceName -VersionValue $version
 
     Write-Host "Mise a jour terminee."
     Write-Host "InstallPath registre: $resolvedInstallPath"
     Write-Host "ServiceName registre: $ServiceName"
+    Write-Host "Entree Appwiz mise a jour: $AppwizUninstallKeyPath"
     if ($skipConfig) {
         Write-Host "config.json existant conserve (utiliser -OverwriteConfig pour l ecraser)."
     }

--- a/templates/audit.tmpl
+++ b/templates/audit.tmpl
@@ -4,6 +4,33 @@
         <h2 class="mb-0">Audit utilisateur</h2>
         <button id="audit-export-csv" class="btn btn-outline-primary btn-sm" type="button">Export CSV</button>
     </div>
+    <div class="card mb-3">
+        <div class="card-body py-3">
+            <div class="form-row align-items-start">
+                <div class="form-group col-md-3 mb-2">
+                    <label for="audit-filter-users" class="mb-1">Utilisateurs</label>
+                    <select id="audit-filter-users" class="form-control form-control-sm" multiple size="5"></select>
+                    <small class="form-text text-muted">Selection multiple possible</small>
+                </div>
+                <div class="form-group col-md-3 mb-2">
+                    <label for="audit-filter-actions" class="mb-1">Actions</label>
+                    <select id="audit-filter-actions" class="form-control form-control-sm" multiple size="5"></select>
+                    <small class="form-text text-muted">Selection multiple possible</small>
+                </div>
+                <div class="form-group col-md-2 mb-2">
+                    <label for="audit-filter-date-from" class="mb-1">Date debut</label>
+                    <input id="audit-filter-date-from" type="datetime-local" class="form-control form-control-sm" />
+                </div>
+                <div class="form-group col-md-2 mb-2">
+                    <label for="audit-filter-date-to" class="mb-1">Date fin</label>
+                    <input id="audit-filter-date-to" type="datetime-local" class="form-control form-control-sm" />
+                </div>
+                <div class="form-group col-md-2 mb-2 d-flex align-items-center">
+                    <button id="audit-filter-reset" class="btn btn-outline-secondary btn-sm w-100" type="button">Reinitialiser</button>
+                </div>
+            </div>
+        </div>
+    </div>
     <div id="audit-table-block">
         <table id="audit-table" class="display table table-bordered table-sm" style="width:100%">
             <thead>

--- a/templates/menu.tmpl
+++ b/templates/menu.tmpl
@@ -50,7 +50,7 @@
     </div>
 </div>
 <script src="/web/user_session.js"></script>
-<aside class="main-sidebar sidebar-dark-primary elevation-4">
+<aside class="main-sidebar sidebar-dark-primary elevation-4 sidebar-modern">
     <a href="/web" class="brand-link">
         <span class="brand-text font-weight-light">DSC Admin Console</span>
     </a>

--- a/web/admin_audit.js
+++ b/web/admin_audit.js
@@ -3,18 +3,54 @@ $(document).ready(function() {
         return;
     }
 
+    function selectedValues(selector) {
+        const values = $(selector).val();
+        return Array.isArray(values) ? values : [];
+    }
+
+    function loadFilterOptions() {
+        $.get('/api/v1/audit/filters')
+            .done(function(resp) {
+                const users = (resp && Array.isArray(resp.users)) ? resp.users : [];
+                const actions = (resp && Array.isArray(resp.actions)) ? resp.actions : [];
+
+                const $userSelect = $('#audit-filter-users');
+                const $actionSelect = $('#audit-filter-actions');
+                $userSelect.empty();
+                $actionSelect.empty();
+
+                users.forEach(function(user) {
+                    $userSelect.append($('<option>', { value: user, text: user }));
+                });
+                actions.forEach(function(action) {
+                    $actionSelect.append($('<option>', { value: action, text: action }));
+                });
+            });
+    }
+
     const table = $('#audit-table').DataTable({
         processing: true,
         serverSide: true,
+        ordering: true,
         autoWidth: false,
         pageLength: 20,
         lengthMenu: [20, 50, 100],
         order: [[4, 'desc']],
         ajax: function(data, callback) {
+            const orderColumn = (data.order && data.order.length > 0) ? data.order[0].column : 4;
+            const orderDir = (data.order && data.order.length > 0) ? data.order[0].dir : 'desc';
             $.get('/api/v1/audit', {
                 draw: data.draw,
                 start: data.start,
                 length: data.length,
+                'order[0][column]': orderColumn,
+                'order[0][dir]': orderDir,
+                orderColumn: orderColumn,
+                orderDir: orderDir,
+                users: selectedValues('#audit-filter-users').join(','),
+                actions: selectedValues('#audit-filter-actions').join(','),
+                date_from: $('#audit-filter-date-from').val() || '',
+                date_to: $('#audit-filter-date-to').val() || '',
                 'search[value]': (data.search && data.search.value) ? data.search.value : ''
             })
                 .done(function(resp) {
@@ -43,9 +79,32 @@ $(document).ready(function() {
         ]
     });
 
+    $('#audit-filter-users, #audit-filter-actions, #audit-filter-date-from, #audit-filter-date-to').on('change', function() {
+        table.ajax.reload();
+    });
+
+    $('#audit-filter-reset').on('click', function() {
+        $('#audit-filter-users').val([]);
+        $('#audit-filter-actions').val([]);
+        $('#audit-filter-date-from').val('');
+        $('#audit-filter-date-to').val('');
+        table.search('');
+        table.ajax.reload();
+    });
+
+    loadFilterOptions();
+
     $('#audit-export-csv').on('click', function() {
         const search = table.search() || '';
-        const url = '/api/v1/audit/export?search=' + encodeURIComponent(search);
+        const users = selectedValues('#audit-filter-users').join(',');
+        const actions = selectedValues('#audit-filter-actions').join(',');
+        const dateFrom = $('#audit-filter-date-from').val() || '';
+        const dateTo = $('#audit-filter-date-to').val() || '';
+        const url = '/api/v1/audit/export?search=' + encodeURIComponent(search)
+            + '&users=' + encodeURIComponent(users)
+            + '&actions=' + encodeURIComponent(actions)
+            + '&date_from=' + encodeURIComponent(dateFrom)
+            + '&date_to=' + encodeURIComponent(dateTo);
         window.location.href = url;
     });
 });

--- a/web/reports.js
+++ b/web/reports.js
@@ -51,40 +51,24 @@ $(document).ready(function() {
     $(window).on('resize', function() {
         $('#agents-table').DataTable().columns.adjust().responsive.recalc();
     });
-    $.getJSON('/api/v1/agents', function(agents) {
-        // Affiche le nombre total d'agents
-        $('#total-agents').text(agents.length);
-        // Calcule le nombre d'agents par état principal
-        let ok = 0, err = 0, pendingEnroll = 0, pendingApply = 0;
-        agents.forEach(a => {
-            if (!a.state) return;
-            switch (a.state.toLowerCase()) {
-                case 'success':
-                    ok++;
-                    break;
-                case 'ok':
-                    ok++;
-                    break;
-                case 'failure':
-                    err++;
-                    break;
-                case 'waiting_for_registration':
-                    pendingEnroll++;
-                    break;
-                case 'pending_apply':
-                    pendingApply++;
-                    break;
-                default:
-                    // ignore or handle as needed
-                    break;
-            }
-        });
+    $.getJSON('/api/v1/agents?count=1', function(data) {
+        if (data && typeof data.count !== 'undefined') {
+            $('#total-agents').text(data.count);
+        }
+    });
+
+    $.getJSON('/api/v1/agents?stats', function(stats) {
+        let ok = (stats && typeof stats.compliant !== 'undefined') ? stats.compliant : 0;
+        let err = (stats && typeof stats.failed !== 'undefined') ? stats.failed : 0;
+        let pendingEnroll = (stats && typeof stats.pending_enroll !== 'undefined') ? stats.pending_enroll : 0;
+        let pendingApply = (stats && typeof stats.pending_apply !== 'undefined') ? stats.pending_apply : 0;
+
         // Affiche le camembert avec 4 catégories
         const ctx = document.getElementById('agents-pie').getContext('2d');
         const chart = new Chart(ctx, {
             type: 'pie',
             data: {
-                labels: ['success', 'Failed', 'Pending Enroll', 'Pending Apply'],
+                labels: ['Compliant', 'Failed', 'Pending Enroll', 'Pending Apply'],
                 datasets: [{
                     data: [ok, err, pendingEnroll, pendingApply],
                     backgroundColor: ['#28a745', '#dc3545', '#6c757d', '#ffc107'],

--- a/web/style.css
+++ b/web/style.css
@@ -7,3 +7,107 @@ button { margin: 0.2em; }
 #configs-section { margin-top: 2em; }
 form { margin-top: 1em; }
 input[type=text] { padding: 0.3em; margin-right: 0.5em; }
+
+/* Modernized left sidebar theme (scoped to avoid global regressions). */
+.sidebar-modern {
+	--sb-bg-top: #0f172a;
+	--sb-bg-bottom: #1e293b;
+	--sb-item-hover: rgba(148, 163, 184, 0.09);
+	--sb-item-active: rgba(148, 163, 184, 0.14);
+	--sb-item-text: #dbeafe;
+	--sb-item-muted: #94a3b8;
+	background: linear-gradient(180deg, var(--sb-bg-top) 0%, var(--sb-bg-bottom) 100%);
+	color: var(--sb-item-text);
+	border-right: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.sidebar-modern .brand-link {
+	border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+	background: rgba(15, 23, 42, 0.45);
+	padding-top: 1rem;
+	padding-bottom: 1rem;
+}
+
+.sidebar-modern .brand-text {
+	color: #e2e8f0;
+	letter-spacing: 0.02em;
+	font-weight: 600;
+}
+
+.sidebar-modern .nav-sidebar .nav-link {
+	color: var(--sb-item-text);
+	border-radius: 8px;
+	margin: 0.2rem 0.55rem;
+	padding-top: 0.62rem;
+	padding-bottom: 0.62rem;
+	transition: background-color 150ms ease, color 150ms ease;
+}
+
+.sidebar-modern .nav-sidebar .nav-link:hover {
+	background: var(--sb-item-hover);
+	color: #f8fafc;
+}
+
+.sidebar-modern .nav-sidebar .nav-link.active {
+	background: var(--sb-item-active);
+	color: #ffffff;
+	box-shadow: none;
+	border-left: 3px solid rgba(125, 211, 252, 0.6);
+}
+
+.sidebar-modern .nav-sidebar .nav-link .nav-icon {
+	width: 1.7rem;
+	text-align: center;
+	margin-right: 0.45rem;
+	background: transparent;
+	color: #cbd5e1;
+	transition: color 150ms ease;
+}
+
+.sidebar-modern .nav-sidebar .nav-link:hover .nav-icon,
+.sidebar-modern .nav-sidebar .nav-link.active .nav-icon {
+	color: #ffffff;
+	background: transparent;
+}
+
+.sidebar-modern .nav-treeview {
+	margin-left: 0.4rem;
+	border-left: 1px dashed rgba(148, 163, 184, 0.3);
+	padding-left: 0.2rem;
+}
+
+.sidebar-modern .nav-treeview > .nav-item > .nav-link {
+	color: #cbd5e1;
+	font-size: 0.94rem;
+	padding-top: 0.5rem;
+	padding-bottom: 0.5rem;
+	border-left: 3px solid transparent;
+}
+
+.sidebar-modern .nav-treeview > .nav-item > .nav-link:hover {
+	background: rgba(148, 163, 184, 0.07);
+	color: #e2e8f0;
+}
+
+.sidebar-modern .nav-treeview > .nav-item > .nav-link.active {
+	background: var(--sb-item-active);
+	color: #ffffff;
+	border-left-color: rgba(125, 211, 252, 0.6);
+}
+
+.sidebar-modern .nav-header,
+.sidebar-modern p {
+	margin-bottom: 0;
+}
+
+@media (max-width: 991.98px) {
+	.sidebar-modern .brand-link {
+		padding-top: 0.85rem;
+		padding-bottom: 0.85rem;
+	}
+
+	.sidebar-modern .nav-sidebar .nav-link {
+		margin-left: 0.45rem;
+		margin-right: 0.45rem;
+	}
+}

--- a/web/style.css
+++ b/web/style.css
@@ -13,7 +13,7 @@ input[type=text] { padding: 0.3em; margin-right: 0.5em; }
 	--sb-bg-top: #0f172a;
 	--sb-bg-bottom: #1e293b;
 	--sb-item-hover: rgba(148, 163, 184, 0.09);
-	--sb-item-active: rgba(148, 163, 184, 0.14);
+	--sb-item-active: #FFFFFF1A;
 	--sb-item-text: #dbeafe;
 	--sb-item-muted: #94a3b8;
 	background: linear-gradient(180deg, var(--sb-bg-top) 0%, var(--sb-bg-bottom) 100%);
@@ -48,8 +48,11 @@ input[type=text] { padding: 0.3em; margin-right: 0.5em; }
 	color: #f8fafc;
 }
 
-.sidebar-modern .nav-sidebar .nav-link.active {
+.sidebar-modern .nav-sidebar .nav-link.active,
+.sidebar-modern .menu-open > .nav-link,
+.sidebar-modern .nav-sidebar > .nav-item > .nav-link.active {
 	background: var(--sb-item-active);
+	background-color: var(--sb-item-active) !important;
 	color: #ffffff;
 	box-shadow: none;
 	border-left: 3px solid rgba(125, 211, 252, 0.6);

--- a/web/user_session.js
+++ b/web/user_session.js
@@ -100,13 +100,43 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 // Active dynamiquement le menu selon l'URL
 document.addEventListener('DOMContentLoaded', function() {
-    var path = window.location.pathname;
+    var normalizePath = function(value) {
+        if (!value) {
+            return '/';
+        }
+        if (value.length > 1 && value.endsWith('/')) {
+            return value.slice(0, -1);
+        }
+        return value;
+    };
+
+    var path = normalizePath(window.location.pathname);
+
+    document.querySelectorAll('.main-sidebar .nav-item.has-treeview').forEach(function(item) {
+        item.classList.remove('menu-open');
+    });
+
     document.querySelectorAll('.main-sidebar .nav-link').forEach(function(link) {
-        // Retire la classe active de tous
         link.classList.remove('active');
-        // Active si correspond à l'URL courante
-        if (link.getAttribute('href') === path) {
-            link.classList.add('active');
+    });
+
+    var links = document.querySelectorAll('.main-sidebar .nav-link[href]');
+    links.forEach(function(link) {
+        var href = link.getAttribute('href');
+        if (!href || href === '#') {
+            return;
+        }
+
+        var linkPath = normalizePath(href.split('?')[0].split('#')[0]);
+        if (linkPath !== path) {
+            return;
+        }
+
+        link.classList.add('active');
+
+        var parentTree = link.closest('.nav-item.has-treeview');
+        if (parentTree) {
+            parentTree.classList.add('menu-open');
         }
     });
 });


### PR DESCRIPTION
# Release v1.1.4

Date: 2026-06-14

Stabilization and UX/API improvement release, focused on the audit page, dashboard load reduction, Windows installation workflow, and startup robustness.

## Changes

### API and Performance

- Added `GET /api/v1/agents?stats` to return consolidated counters (compliant, failed, pending_enroll, pending_apply).
- Reduced dashboard load by using precomputed stats instead of client-side aggregations.

Impacted files:
- handlers/agent_api.go
- web/reports.js
- doc/APIv1.md

### Audit (WebUI + API)

- Added server-side DataTables ordering support (column mapping + direction).
- Added combined filters: users, actions, date_from, date_to.
- Aligned CSV export with active filters (same filtering logic as list endpoint).
- Added `GET /api/v1/audit/filters` to load filter options.
- UI adjustments for the filters bar (alignment improvements).

Impacted files:
- handlers/audit_list.go
- internal/routes/web_routes.go
- web/admin_audit.js
- templates/audit.tmpl
- doc/APIv1.md

### Scheduler / Startup Robustness

- Fixed handling of scheduler runs stuck in running state at startup.
- For MSSQL, switched to typed date parameters to avoid format-sensitive implicit conversions.

Impacted file:
- internal/db/scheduler_history.go

### Packaging and Windows Scripts

- Added/improved scripts:
  - `scripts/install-windows.ps1`
  - `scripts/update-windows.ps1`
  - `scripts/uninstall-windows.ps1`
- Added registry metadata handling (install path, service, version) and Appwiz integration.
- Included the `scripts/` folder in the release ZIP artifact.

Impacted files:
- scripts/install-windows.ps1
- scripts/update-windows.ps1
- scripts/uninstall-windows.ps1
- .github/workflows/release.yml

### UI

- Style adjustments (navigation/left sidebar and active states) and improved overall visual consistency.

Impacted files:
- templates/menu.tmpl
- web/style.css

## Database

- No new mandatory migration specific to v1.1.4.
- If upgrading from a version older than v1.1.3p2, apply previously required migrations before moving to v1.1.4.

## Update Procedure

Run these steps in order:

1. Stop the service.
2. Back up the database and `config.json`.
3. Replace application files with those from the v1.1.4 ZIP (including `scripts/`).
4. If required by your version history, run missing SQL migrations.
5. Restart the service.

## Post-Update Checks (Recommended)

- Verify access to `/web/admin/audit`.
- Verify ordering/filtering/CSV export on audit.
- Verify dashboard behavior (fast counters and chart loading).
- Verify Windows scripts are present in the deployed package.
- Verify startup logs and absence of critical SQL errors.

## Notes

- A `401` on `/api/v1/audit` indicates a missing or expired authenticated session.
- The release check may report an older remote version depending on the publication repository state.
